### PR TITLE
Solve issue of ModuleNotFoundError: No module named 'matplotlib'

### DIFF
--- a/find_my_citers/requirements.txt
+++ b/find_my_citers/requirements.txt
@@ -1,1 +1,2 @@
 pys2
+matplotlib


### PR DESCRIPTION
Add `matplotlib` into `requirements.txt`

The original one:
cat `requirements.txt`
```
pys2
```

Now:
cat `requirements.txt`
```
pys2
matplotlib
```
